### PR TITLE
look for base prefix only in strings

### DIFF
--- a/lib/genspec/matchers/base.rb
+++ b/lib/genspec/matchers/base.rb
@@ -21,7 +21,7 @@ module GenSpec
       def matches?(generator)
         @described = generator[:described]
         base = nil
-        base, @described = @described.split(/:/) if @described =~ /:/
+        base, @described = @described.split(/:/) if @described.is_a?(String) && @described =~ /:/
         @args = generator[:args]
         @generator_options = generator[:generator_options]
         @shell = GenSpec::Shell.new(generator[:output] || "", generator[:input] || "")


### PR DESCRIPTION
This handles deprecation of =~ for non-strings in Ruby 3.2. For non-strings this line was a no-op already.